### PR TITLE
Potential fix for code scanning alert no. 1: Application backup allowed

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,17 +3,10 @@
 
 name: "CodeQL Config for Android"
 
-# Disable default queries and use only custom ones
-# disable-default-queries: true
-
 # Query suites to run
 queries:
   - uses: security-extended
   - uses: security-and-quality
-
-# Custom query packs (optional)
-# packs:
-#   - codeql/java-queries
 
 # Paths to exclude from analysis
 paths-ignore:
@@ -26,18 +19,30 @@ paths-ignore:
   - '**/proguard-rules.pro'
   - '**/*.md'
   - '**/docs/**'
+  - '**/res/**'  # Exclude resources (XML, etc.)
+  - '**/assets/**'
+  - '**/.gradle/**'
+  - '**/gradle/**'
+  - '**/buildSrc/**'
 
-# Paths to include (optional - only these will be analyzed)
-# paths:
-#   - 'app/src/main/**'
-#   - 'library/src/main/**'
+# Paths to include
+paths:
+  - 'app/src/main/kotlin/**'
+  - 'app/src/main/java/**'
 
-# Query filters - exclude specific queries
-# query-filters:
-#   - exclude:
-#       id: java/unused-local-variable
-#   - exclude:
-#       problem.severity: recommendation
+# Query filters - exclude low-priority queries
+query-filters:
+  # Exclude informational findings
+  -
+    exclude:
+      problem.severity: recommendation
+  # Exclude specific Android queries that may timeout
+  -
+    exclude:
+      id: java/android/implicit-pendingintent
+  -
+    exclude:
+      id: java/android/unsafe-android-webview-fetch
 
 # Additional configuration for Android
 android:
@@ -61,10 +66,10 @@ performance:
   threads: 0  # 0 = auto-detect
 
   # Memory limit (MB)
-  ram: 4096
+  ram: 6144
 
   # Timeout for queries (seconds)
-  timeout: 900
+  timeout: 1800
 
 # Severity levels to report
 # Options: error, warning, recommendation, note

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
   analyze:
     name: Analyze Code
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false
@@ -65,6 +65,8 @@ jobs:
       -
         name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
 
       -
         name: Make gradlew executable
@@ -78,17 +80,23 @@ jobs:
           languages: ${{ matrix.language }}
           # Queries to run: default, security-extended, security-and-quality
           queries: security-extended
-          # Custom queries (optional)
-          # config-file: .github/codeql/codeql-config.yml
+          config-file: .github/codeql/codeql-config.yml
 
       # Build the project for CodeQL analysis
       # CodeQL needs to see how code is used
       -
         name: Build project
         run: |
-          ./gradlew assembleDebug --no-daemon --stacktrace
+          ./gradlew assembleDebug \
+            --no-daemon \
+            --no-build-cache \
+            --stacktrace \
+            -x lint \
+            -x lintVitalRelease \
+            -x test \
+            -x detekt
 
-      # Perform CodeQL Analysis
+      # Perform CodeQL Analysis z optymalizacjami
       -
         name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
@@ -96,10 +104,12 @@ jobs:
           category: "/language:${{ matrix.language }}"
           # Upload results even if there are no findings
           upload: true
+          # Threads for analysis (default: auto)
+          threads: 4
           # SARIF output directory
           output: codeql-results
-          # Threads for analysis (default: auto)
-          threads: 2
+          # Used RAM
+          ram: 6144
 
       # Upload SARIF file as artifact (optional)
       -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2025-10-11
+
+### FIXED
+
+- Set `android:allowBackup` to false
+
 ## [1.4.1] - 2025-10-11
 
 ### ADDED

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "pl.rk.gac"
         minSdk = 28
         targetSdk = 36
-        versionCode = 15
-        versionName = "1.4.1"
+        versionCode = 16
+        versionName = "1.4.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application
         android:name="pl.rk.gac.PericopeApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/docs/CODEQL_QUICKSTART.md
+++ b/docs/CODEQL_QUICKSTART.md
@@ -387,6 +387,60 @@ Add to `.github/workflows/codeql.yml`:
           -x test
 ```
 
+### CodeQL Times Out
+
+**Problem**: Analysis takes too long and times out after 30+ minutes
+
+**Symptom**: Workflow cancelled after loading many queries
+
+**Solutions**:
+
+**Option 1: Increase timeout**
+
+```yaml
+jobs:
+    analyze:
+        timeout-minutes: 60  # Zwiększ z 30 do 60
+```
+
+**Option 2: Use security-only queries** (RECOMMENDED)
+
+```yaml
+-   uses: github/codeql-action/init@v3
+    with:
+        queries: security-only  # Zamiast security-extended
+```
+
+**Option 3: Exclude more paths**
+
+```yaml
+# .github/codeql/codeql-config.yml
+paths-ignore:
+    - '**/build/**'
+    - '**/test/**'
+    - '**/res/**'  # Dodaj resources
+    - '**/assets/**'
+
+paths:
+    - 'app/src/main/kotlin/**'  # Tylko główny kod
+```
+
+**Option 4: Use lite workflow**
+
+```bash
+# Użyj .github/workflows/codeql-lite.yml
+# Szybsza wersja z minimalnymi queries
+```
+
+**Option 5: Allocate more resources**
+
+```yaml
+-   uses: github/codeql-action/analyze@v3
+    with:
+        threads: 4  # Więcej wątków
+        ram: 6144   # Więcej RAM (6GB)
+```
+
 ### No Results Shown
 
 **Problem**: Scan completes but no results


### PR DESCRIPTION
Potential fix for [https://github.com/rkociniewski/gac/security/code-scanning/1](https://github.com/rkociniewski/gac/security/code-scanning/1)

To resolve this issue, you should set the `android:allowBackup` attribute to `"false"` within the `<application>` tag in your manifest file. This prevents Android from backing up your app’s private data to cloud or local sources, greatly improving security (especially if your app handles sensitive data). Only one line needs to be changed: line 6 in `app/src/main/AndroidManifest.xml`, replacing `android:allowBackup="true"` with `android:allowBackup="false"`. No other imports or code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
